### PR TITLE
add support for overriding the TLS clientSupported member in TLSSettingsSimple

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -57,7 +57,6 @@ import qualified Control.Exception as E
 import qualified System.IO.Error as E (mkIOError, eofErrorType)
 
 import qualified Network.TLS as TLS
-import qualified Network.TLS.Extra as TLS
 
 import System.X509 (getSystemCertificateStore)
 
@@ -123,10 +122,7 @@ initConnectionContext = ConnectionContext <$> getSystemCertificateStore
 makeTLSParams :: ConnectionContext -> ConnectionID -> TLSSettings -> TLS.ClientParams
 makeTLSParams cg cid ts@(TLSSettingsSimple {}) =
     (TLS.defaultParamsClient (fst cid) portString)
-        { TLS.clientSupported =
-            case settingClientSupported ts of
-              Nothing -> def { TLS.supportedCiphers = TLS.ciphersuite_default }
-              Just cs -> cs
+        { TLS.clientSupported = settingClientSupported ts
         , TLS.clientShared    = def
             { TLS.sharedCAStore         = globalCertificateStore cg
             , TLS.sharedValidationCache = validationCache

--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -123,7 +123,10 @@ initConnectionContext = ConnectionContext <$> getSystemCertificateStore
 makeTLSParams :: ConnectionContext -> ConnectionID -> TLSSettings -> TLS.ClientParams
 makeTLSParams cg cid ts@(TLSSettingsSimple {}) =
     (TLS.defaultParamsClient (fst cid) portString)
-        { TLS.clientSupported = def { TLS.supportedCiphers = TLS.ciphersuite_default }
+        { TLS.clientSupported =
+            case settingClientSupported ts of
+              Nothing -> def { TLS.supportedCiphers = TLS.ciphersuite_default }
+              Just cs -> cs
         , TLS.clientShared    = def
             { TLS.sharedCAStore         = globalCertificateStore cg
             , TLS.sharedValidationCache = validationCache

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -18,6 +18,7 @@ import Data.ByteString (ByteString)
 
 import Network.Socket (PortNumber, Socket)
 import qualified Network.TLS as TLS
+import qualified Network.TLS.Extra as TLS
 
 import System.IO (Handle)
 
@@ -75,15 +76,15 @@ data TLSSettings
                                                            --   will always re-established their context.
                                                            --   Not Implemented Yet.
              , settingUseServerName                :: Bool -- ^ Use server name extension. Not Implemented Yet.
-             , settingClientSupported              :: Maybe TLS.Supported
-                                                           -- ^ Override defaults for the 'TLS.clientSupported'
+             , settingClientSupported              :: TLS.Supported
+                                                           -- ^ Used for the 'TLS.clientSupported'
                                                            --   member of 'TLS.ClientParams'.
              } -- ^ Simple TLS settings. recommended to use.
     | TLSSettings TLS.ClientParams -- ^ full blown TLS Settings directly using TLS.Params. for power users.
     deriving (Show)
 
 instance Default TLSSettings where
-    def = TLSSettingsSimple False False False Nothing
+    def = TLSSettingsSimple False False False def { TLS.supportedCiphers = TLS.ciphersuite_default }
 
 type ConnectionID = (HostName, PortNumber)
 

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -75,12 +75,15 @@ data TLSSettings
                                                            --   will always re-established their context.
                                                            --   Not Implemented Yet.
              , settingUseServerName                :: Bool -- ^ Use server name extension. Not Implemented Yet.
+             , settingClientSupported              :: Maybe TLS.Supported
+                                                           -- ^ Override defaults for the 'TLS.clientSupported'
+                                                           --   member of 'TLS.ClientParams'.
              } -- ^ Simple TLS settings. recommended to use.
     | TLSSettings TLS.ClientParams -- ^ full blown TLS Settings directly using TLS.Params. for power users.
     deriving (Show)
 
 instance Default TLSSettings where
-    def = TLSSettingsSimple False False False
+    def = TLSSettingsSimple False False False Nothing
 
 type ConnectionID = (HostName, PortNumber)
 


### PR DESCRIPTION
This is so we can manipulate these TLS settings even when using a connection manager like the http-client package does. See
https://github.com/kazu-yamamoto/crypton-connection/issues/2 for details.