### PR TITLE
data-default-class -> data-default

### DIFF
--- a/Network/Connection.hs
+++ b/Network/Connection.hs
@@ -65,7 +65,7 @@ import Network.Socket
 import qualified Network.Socket.ByteString as N
 
 import Data.Tuple (swap)
-import Data.Default.Class
+import Data.Default
 import Data.Data
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B

--- a/Network/Connection/Types.hs
+++ b/Network/Connection/Types.hs
@@ -12,7 +12,7 @@ module Network.Connection.Types
 
 import Control.Concurrent.MVar (MVar)
 
-import Data.Default.Class
+import Data.Default
 import Data.X509.CertificateStore
 import Data.ByteString (ByteString)
 

--- a/crypton-connection.cabal
+++ b/crypton-connection.cabal
@@ -27,7 +27,7 @@ Library
                    , basement
                    , bytestring
                    , containers
-                   , data-default-class
+                   , data-default >= 0.8
                    , network >= 2.6.3
                    , tls >= 1.7 && < 2.2
                    , socks >= 0.6


### PR DESCRIPTION
data-default 0.8 deprecates data-default-class by moving the `Default` class from `Data.Default.Class` to `Data.Default`.

This is used upstream in `tls`.

See: https://github.com/kazu-yamamoto/crypton-certificate/pull/11
See: https://github.com/haskell-tls/hs-tls/pull/486
See: https://github.com/commercialhaskell/stackage/issues/7545