### PR TITLE
Swap `crypton-socks` for existing unmaintained `socks` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Version 0.4.5
+
+* Swap `crypton-socks` for unmaintained `socks` dependency.
+
 ## Version 0.4.4
 
 * Remove unused packages.
@@ -30,4 +34,3 @@
 ## Version 0.3.1
 
 * The first release to support crypton.
-

--- a/crypton-connection.cabal
+++ b/crypton-connection.cabal
@@ -1,5 +1,5 @@
 Name:                crypton-connection
-Version:             0.4.4
+Version:             0.4.5
 Description:
     Simple network library for all your connection needs.
     .
@@ -29,7 +29,7 @@ Library
                    , data-default
                    , network >= 2.6.3
                    , tls >= 1.7 && < 2.2
-                   , socks >= 0.6
+                   , crypton-socks >= 0.6
                    , crypton-x509-store >= 1.5
                    , crypton-x509-system >= 1.5
   Exposed-modules:   Network.Connection


### PR DESCRIPTION
See:
* #9 
* https://discourse.haskell.org/t/forking-socks-as-crypton-socks/12436
* https://github.com/mpilgrem/crypton-socks